### PR TITLE
Add error logging for missing price_id in Stripe link creation

### DIFF
--- a/src/app/api/stripe/create-link/route.ts
+++ b/src/app/api/stripe/create-link/route.ts
@@ -26,6 +26,7 @@ export async function POST(req: NextRequest) {
     const priceId = priceLookup.data?.[0]?.id;
 
     if (!priceId) {
+        console.error("❌ Aucun price_id trouvé pour le plan :", plan);
         return NextResponse.json({ error: "Prix introuvable pour ce plan." }, { status: 400 });
     }
 


### PR DESCRIPTION
- Implemented console error logging in the Stripe create link route to capture instances where a price_id is not found for a given plan, improving debugging capabilities and error handling.