### PR TITLE
Update Supabase user table reference in Stripe webhook

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -115,7 +115,7 @@ export async function POST(req: NextRequest) {
 
         // Trouver l'utilisateur dans Supabase par email
         const { data: userData, error: userError } = await supabase
-            .from("users")
+            .from("auth.users")
             .select("id")
             .eq("email", customer.email)
             .single();


### PR DESCRIPTION
- Changed the Supabase table reference from "users" to "auth.users" to align with the updated database schema.
- This modification ensures accurate user retrieval by email during the webhook processing.