### PR TITLE
Refactor user retrieval in Stripe webhook to use RPC call

### DIFF
--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -115,9 +115,7 @@ export async function POST(req: NextRequest) {
 
         // Trouver l'utilisateur dans Supabase par email
         const { data: userData, error: userError } = await supabase
-            .from("auth.users")
-            .select("id")
-            .eq("email", customer.email)
+            .rpc('get_user_by_email', { user_email: customer.email })
             .single();
 
         if (userError || !userData) {


### PR DESCRIPTION
- Updated the user retrieval logic in the Stripe webhook from a direct table query to a remote procedure call (RPC) using 'get_user_by_email'.
- This change enhances performance and aligns with the updated database access patterns.